### PR TITLE
Fix long varchar error

### DIFF
--- a/src/value.cpp
+++ b/src/value.cpp
@@ -231,23 +231,17 @@ char *Value::as_c_str(unsigned long &size) const
     size= 0;
     return 0;
   }
+
   /*
    Length encoded; First byte is length of string.
   */
-  int metadata_length= m_size > 251 ? 2: 1;
+  int metadata_length= m_metadata > 255 ? 2 : 1;
   /*
    Size is length of the character string; not of the entire storage
   */
   size= m_size - metadata_length;
 
-  char *str = const_cast<char *>(m_storage + metadata_length);
-
-  if (m_type == mysql::system::MYSQL_TYPE_VARCHAR && m_metadata > 255) {
-    str++;
-    size--;
-  }
-
-  return str;
+  return const_cast<char *>(m_storage + metadata_length);
 }
 
 unsigned char *Value::as_blob(unsigned long &size) const


### PR DESCRIPTION
It was truncating the first character of the string when the varchar had more than 255 characters.
