### PR TITLE
Fix leak during password hashing

### DIFF
--- a/src/tcp_driver.cpp
+++ b/src/tcp_driver.cpp
@@ -786,6 +786,7 @@ int hash_sha1(boost::uint8_t *output, ...)
   }
   EVP_DigestFinal_ex(hash_context, (unsigned char *)output, (unsigned int *)&result);
   va_end(ap);
+  EVP_MD_CTX_destroy(hash_context);
   return result;
 }
 


### PR DESCRIPTION
The libcrypto context was never free'd and the password hash is
calculated uppon connection. Unfortunately, it seems that a lot of
connections are created so it is possible that this leak is the one
causing serious trouble in production.