### PR TITLE
[DATA-966] Add prefix to homebrew formula

### DIFF
--- a/homebrew/mysql-replication-listener.rb
+++ b/homebrew/mysql-replication-listener.rb
@@ -1,15 +1,15 @@
 require 'formula'
 
 class MysqlReplicationListener < Formula
-  url 'https://bitbucket.org/winebarrel/mysql-replication-listener.git', :tag => '0.0.47-10'
-  homepage 'https://bitbucket.org/winebarrel/mysql-replication-listener'
+  url 'https://github.com/SponsorPay/mysql-replication-listener.git'
+  homepage 'https://github.com/SponsorPay/mysql-replication-listener'
 
   depends_on 'cmake'
   depends_on 'boost'
   #depends_on 'openssl'
 
   def install
-    system 'cmake', '.'
+    system 'cmake', "-DCMAKE_INSTALL_PREFIX:PATH=#{prefix}", '.'
     system 'make'
     system 'make install'
   end


### PR DESCRIPTION
  - In order for homebrew to manage the installation of the library,
    cmake must install the files in thw right directory, indicated by
    the prefix variable.
  - Updates urls to point to the fyber fork instead of the original
    repository.